### PR TITLE
fix possessive_maybe test and export it

### DIFF
--- a/src/ReadableRegex.jl
+++ b/src/ReadableRegex.jl
@@ -37,7 +37,7 @@ export lazy_at_least
 export possessive_zero_or_more
 export possessive_one_or_more
 export possessive_between
-# export possessive_maybe
+export possessive_maybe
 export possessive_at_least
 
 export LETTER
@@ -273,7 +273,7 @@ lazy_at_least(n, r) = at_least(n, r) * rs"?"
 possessive_zero_or_more(r) = zero_or_more(r) * rs"+"
 possessive_one_or_more(r) = one_or_more(r) * rs"+"
 possessive_between(low, high, r) = between(low, high, r) * rs"+"
-# possessive_maybe(r) = maybe(r) * rs"+"
+possessive_maybe(r) = maybe(r) * rs"+"
 possessive_at_least(n, r) = at_least(n, r) * rs"+"
 
 function look_for(r;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ end
             not_after = ".",
             not_before = NON_SEPARATOR)
 
-    @test collect(m.match for m in eachmatch(reg, str4)) == ["1", "-5", "60", "700", "+9000"]      
+    @test collect(m.match for m in eachmatch(reg, str4)) == ["1", "-5", "60", "700", "+9000"]
 end
 
 @testset "Numbers" begin
@@ -146,9 +146,11 @@ end
     @test match(at_least(2, DIGIT) * "4", str2).match == "1234"
     @test match(possessive_at_least(2, DIGIT) * "4", str2) === nothing
 
-    # don't quite understand why this doesn't work, leave it out for now
-    # str3 = "123"
+    str3 = "123"
 
-    # @test match(maybe("123") * "3", str3).match == "3"
-    # @test match(possessive_maybe("123") * "3", str3) === nothing
+    @test match(maybe("123") * "3", str3).match == "3"
+    @test match(possessive_maybe("123") * "3", str3).match == "3"
+    @test match(possessive_maybe("12") * "3", str3).match == "123"
+
+    @test Regex(possessive_maybe("12") * "3") == r"(?:12)?+3"
 end


### PR DESCRIPTION
As far as we could tell, there was nothing wrong with the `possessive_maybe` implementation. The tests just were not asserting the right thing!

Also adds a new type of unit test that checks the direct regex conversion rather than test the regex itself.